### PR TITLE
External configuration and default values

### DIFF
--- a/arduino/library/avr-debugger/src/avr8-stub.h
+++ b/arduino/library/avr-debugger/src/avr8-stub.h
@@ -101,7 +101,9 @@ extern "C" {
  * for a single step in the debugger.
  *
  * */
-#define		AVR8_BREAKPOINT_MODE	(1)
+#ifndef	AVR8_BREAKPOINT_MODE
+	#define	AVR8_BREAKPOINT_MODE	(1)
+#endif
 
 
 /**
@@ -136,7 +138,9 @@ extern "C" {
  * could cause troubles, because they have higher priority than PCINT and could prevent
  * the debugger from catching breakpoints properly...this needs to be verified.
  */
-#define	AVR8_SWINT_SOURCE	(0)
+#ifndef	AVR8_SWINT_SOURCE
+	#define	AVR8_SWINT_SOURCE	(0)
+#endif
 
 
 /**
@@ -151,7 +155,9 @@ extern "C" {
     0 - load from GDB disabled. Load the program using avrdude as usual.
     1 - load from GDB enabled.
 */
-#define	AVR8_LOAD_SUPPORT	(0)
+#ifndef	AVR8_LOAD_SUPPORT
+	#define	AVR8_LOAD_SUPPORT	(0)
+#endif
 
 
 /**

--- a/avr8-stub/avr8-stub.h
+++ b/avr8-stub/avr8-stub.h
@@ -101,7 +101,9 @@ extern "C" {
  * for a single step in the debugger.
  *
  * */
-#define		AVR8_BREAKPOINT_MODE	(1)
+#ifndef	AVR8_BREAKPOINT_MODE
+	#define	AVR8_BREAKPOINT_MODE	(1)
+#endif
 
 
 /**
@@ -136,7 +138,9 @@ extern "C" {
  * could cause troubles, because they have higher priority than PCINT and could prevent
  * the debugger from catching breakpoints properly...this needs to be verified.
  */
-#define	AVR8_SWINT_SOURCE	(0)
+#ifndef	AVR8_SWINT_SOURCE
+	#define	AVR8_SWINT_SOURCE	(0)
+#endif
 
 
 /**
@@ -151,7 +155,9 @@ extern "C" {
     0 - load from GDB disabled. Load the program using avrdude as usual.
     1 - load from GDB enabled.
 */
-#define	AVR8_LOAD_SUPPORT	(0)
+#ifndef	AVR8_LOAD_SUPPORT
+	#define	AVR8_LOAD_SUPPORT	(0)
+#endif
 
 
 /**


### PR DESCRIPTION
Hi,
I did a small modd to make it possible to externaly re-configure the AVR8_BREAKPOINT_MODE, AVR8_LOAD_SUPPORT, AVR8_SWINT_SOURCE defines.
This allows development tools like Arduino or PlatformIO to have specific and local configuration for a project, instead of it being global.
