### PR TITLE
Fast transition from debug to release build

### DIFF
--- a/avr8-stub/avr8-stub.c
+++ b/avr8-stub/avr8-stub.c
@@ -982,11 +982,11 @@ static bool_t gdb_parse_packet(const uint8_t *buff)
 			/* recommended way to reset - activate watchdog */
 			/* note: on newer ARV including ATmega328 the watchdog will stay enabled even after the reset, 
 			 the software should disable it. It seems to be disabled with Arduino...*/
-			wdt_enable(WDTO_15MS);  
-    		while(1) ;		
+			wdt_enable(WDTO_15MS);
+			while(1) ;
 		}
-		else if(memcmp_PF(gdb_ctx->buff, (uintptr_t)PSTR("qRcmd,68616c74"), 14) == 0) {
-			/* halt target  - the same action as D or kill above */
+		else if(memcmp_PF(gdb_ctx->buff, (uintptr_t)PSTR("qRcmd,72756e"), 12) == 0) {
+			/* run - the same action as D or kill above */
 #if (AVR8_BREAKPOINT_MODE == 0 )	/* code is for flash BP only */
 			/* Update the flash so that the program can run after reset without breakpoints */
 			gdb_update_breakpoints();

--- a/avr8-stub/avr_debugger.h
+++ b/avr8-stub/avr_debugger.h
@@ -1,0 +1,41 @@
+#include "avr8-stub.h"
+#include <avr/interrupt.h>
+
+#ifndef AVR_DEBUGGER_H_
+#define AVR_DEBUGGER_H_
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(PLATFORMIO) && defined(__PLATFORMIO_BUILD_DEBUG__)
+    #define __DEBUG__
+#endif
+
+#if defined(__DEBUG__)
+    #define DBG_EXEC(x) x
+#else
+    #define DBG_EXEC(x)
+#endif
+
+#define dbg_breakpoint() { \
+    DBG_EXEC(breakpoint()); \
+    }
+
+#define dbg_init()       { \
+    DBG_EXEC(debug_init()); \
+    }
+
+#define dbg_start()      { \
+    DBG_EXEC(debug_init()); \
+    DBG_EXEC(sei()); \
+    DBG_EXEC(breakpoint()); \
+    }
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* AVR_DEBUGGER_H_ */


### PR DESCRIPTION
These macros have the effect of removing, at compiling time, all the calls to the debug related functions when the firmware is built for release.
This allows a fast and seamless transition from debug to release and has no negative effect over the system performance of firmware size.