### PR TITLE
Fast transition from debug to release build

### DIFF
--- a/avr8-stub/avr_debugger.h
+++ b/avr8-stub/avr_debugger.h
@@ -10,7 +10,9 @@ extern "C" {
 #endif
 
 #if defined(PLATFORMIO) && defined(__PLATFORMIO_BUILD_DEBUG__)
-    #define __DEBUG__
+    #ifndef __DEBUG__
+        #define __DEBUG__
+    #endif
 #endif
 
 #if defined(__DEBUG__)

--- a/avr8-stub/avr_debugger.h
+++ b/avr8-stub/avr_debugger.h
@@ -1,0 +1,41 @@
+#include "avr8-stub.h"
+#include <avr/interrupt.h>
+
+#ifndef AVR_DEBUGGER_H_
+#define AVR_DEBUGGER_H_
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(PLATFORMIO) && defined(__PLATFORMIO_BUILD_DEBUG__)
+    #define __DEBUG__
+#endif
+
+#if defined(__DEBUG__)
+    #define DBG_EXEC(x) x
+#else
+    #define DBG_EXEC(x)
+#endif
+
+#define dbg_breakpoint() { \
+    DBG_EXEC(breakpoint()); \
+    }
+
+#define dbg_init()       { \
+    DBG_EXEC(debug_init()); \
+    }
+
+#define dbg_start()      { \
+    DBG_EXEC(debug_init()); \
+    DBG_EXEC(sei()); \
+    DBG_EXEC(breakpoint()); \
+    }
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* AVR_DEBUGGER_H_ */


### PR DESCRIPTION
These macros have the effect of removing, at compiling time, all the calls to the debug related functions when the firmware is built for release.
This allows a fast and seamless transition from debug to release and has no negative effect over the system performance of firmware size.
Fixes #15