### PR TITLE
Update PlatformIO library manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "name": "avr-debugger",
-    "version": "1.0",
-    "description": "Enables debugging Arduino code.", 
+    "version": "1.1",
+    "description": "Enables debugging Arduino/AVR code with GDB.", 
     "repository": {
         "url": "https://github.com/jdolinay/avr_debug", 
         "type": "git"
@@ -18,7 +18,10 @@
         "exclude": [
             "bootloader",
             "doc", 
-            "hub4com-*"
+            "hub4com-*",
+            "arduino",             
+            "examples/experimental",             
+			"start_proxy*"			
         ]
     }, 
     "authors": [
@@ -31,10 +34,6 @@
     ],
     "build": {
         "includeDir": "avr8-stub",
-        "srcFilter": [
-            "-<*>",
-            "+<arduino/1.8.*>",
-            "+<avr8-stub>"
-        ]
+        "srcDir": "avr8-stub",        
     }
 }

--- a/library.json
+++ b/library.json
@@ -16,14 +16,10 @@
     ], 
     "export": {
         "exclude": [
-            "extras", 
-            "docs", 
-            "tests", 
-            "test", 
-            "*.doxyfile", 
-            "*.pdf"
-        ], 
-        "include": "arduino/library/avr-debugger"
+            "bootloader",
+            "doc", 
+            "hub4com-*"
+        ]
     }, 
     "authors": [
         {
@@ -32,5 +28,13 @@
             "url": null, 
             "email": "j.dolinay@dolinaysoft.com"
         }
-    ]
+    ],
+    "build": {
+        "includeDir": "avr8-stub",
+        "srcFilter": [
+            "-<*>",
+            "+<arduino/1.8.*>",
+            "+<avr8-stub>"
+        ]
+    }
 }


### PR DESCRIPTION
Unfortunately, the current manifest doesn't work out of the box. I propose the following changes:
- Exclude unnecessary folders when exporting the library (it makes sense to export only folders with source files)
- Compile only required files (I suppose Arduino 1.6.5 isn't really commonly used anymore)
- Add default include directory for convenience, so users can simply add `#include "avr8-stub.h"`.

Please correct me if I'm missing something.